### PR TITLE
add reconditioning decay option

### DIFF
--- a/Languages/English/Keyed/Misc.xml
+++ b/Languages/English/Keyed/Misc.xml
@@ -3,6 +3,8 @@
   <PS_ModVersion>Installed mod-version: {0}</PS_ModVersion>
   <PS_IsBad>Count 'reconditioned' as bad</PS_IsBad>
   <PS_IsBadInfo>This makes it possible to remove with mods that remove bad Hediffs, such as MedPod</PS_IsBadInfo>
+  <PS_Decays>Reconditioning decay</PS_Decays>
+  <PS_DecaysInfo>This makes reconditioning decay. Disabling this makes reconditioning permanent without neural cement.</PS_DecaysInfo>
   <PS_ReconWoreOffMessage>This happened because conditioning wore off.</PS_ReconWoreOffMessage>
   <PS_Cancel>Cancel</PS_Cancel>
   <PS_Accept>Accept</PS_Accept>

--- a/Source/PS_ReconPod/PS_ConditioningHelper.cs
+++ b/Source/PS_ReconPod/PS_ConditioningHelper.cs
@@ -228,15 +228,16 @@ public static class PS_ConditioningHelper
 
         if (!IsReconditioned(pawn))
         {
-            var hediff = TryGiveReconditioning(pawn, conData);
-            if (hediff != null)
+            if (LoadedModManager.GetMod<PS_ReconPodMod>().GetSettings<PS_ReconPodSettings>().RecondDecays)
             {
-                DoTraitChange(pawn, conData);
+                var hediff = TryGiveReconditioning(pawn, conData);
+                if (hediff == null)
+                {
+                    Log.Error("PS_ConditioningHelper: Failed to create hediff");
+                }
+
             }
-            else
-            {
-                Log.Error("PS_ConditioningHelper: Failed to create hediff");
-            }
+            DoTraitChange(pawn, conData);
         }
         else
         {

--- a/Source/PS_ReconPod/PS_ConditioningHelper.cs
+++ b/Source/PS_ReconPod/PS_ConditioningHelper.cs
@@ -233,7 +233,7 @@ public static class PS_ConditioningHelper
                 var hediff = TryGiveReconditioning(pawn, conData);
                 if (hediff == null)
                 {
-                    Log.Error("PS_ConditioningHelper: Failed to create hediff");
+                    Log.Error("PS_ConditioningHelper: Reconditioning decay enabled, but failed to create hediff");
                 }
 
             }

--- a/Source/PS_ReconPod/Settings/PS_ReconPodMod.cs
+++ b/Source/PS_ReconPod/Settings/PS_ReconPodMod.cs
@@ -53,6 +53,9 @@ internal class PS_ReconPodMod : Mod
     {
         var listing_Standard = new Listing_Standard();
         listing_Standard.Begin(rect);
+        listing_Standard.CheckboxLabeled("PS_Decays".Translate(), ref Settings.RecondDecays,
+            "PS_DecaysInfo".Translate());
+        if (currentVersion != null)
         listing_Standard.CheckboxLabeled("PS_IsBad".Translate(), ref Settings.RecondIsBad,
             "PS_IsBadInfo".Translate());
         if (currentVersion != null)

--- a/Source/PS_ReconPod/Settings/PS_ReconPodSettings.cs
+++ b/Source/PS_ReconPod/Settings/PS_ReconPodSettings.cs
@@ -17,6 +17,6 @@ internal class PS_ReconPodSettings : ModSettings
     {
         base.ExposeData();
         Scribe_Values.Look(ref RecondIsBad, "RecondIsBad");
-        Scribe_Values.Look(ref RecondDecays, "RecondDecays");
+        Scribe_Values.Look(ref RecondDecays, "RecondDecays", true);
     }
 }

--- a/Source/PS_ReconPod/Settings/PS_ReconPodSettings.cs
+++ b/Source/PS_ReconPod/Settings/PS_ReconPodSettings.cs
@@ -8,6 +8,7 @@ namespace PS_ReconPod;
 internal class PS_ReconPodSettings : ModSettings
 {
     public bool RecondIsBad;
+    public bool RecondDecays;
 
     /// <summary>
     ///     Saving and loading the values
@@ -16,5 +17,6 @@ internal class PS_ReconPodSettings : ModSettings
     {
         base.ExposeData();
         Scribe_Values.Look(ref RecondIsBad, "RecondIsBad");
+        Scribe_Values.Look(ref RecondDecays, "RecondDecays");
     }
 }


### PR DESCRIPTION
initially started as modifying the decay rate, i wanted to make it a bit more permanent in general.

this adds an option to enable or disable the decay rate, however while i've spent decades programming this is the first time i've touched rimworld modding and i don't ordinarily write c#, so this is a draft pending any feedback from yourself on how to make it a bit cleaner. this is more or less to make sure it's something you're interested in merging in or if i should just keep a local fork.

this mr doesn't include a compiled version of the updated source code but i've compiled it locally and use it in my own game. the standard `dotnet build PSReconditioningPod.csproj` works.

things i need to work out:
- making decay default (i.e., as it was prior to this mr), vs not—i couldn't identify how to make a setting default to 'on'; presetting the boolean value to true didn't seem to do this, and spelunking through mendandrecycle (a random mod i picked to work out rimworld's modding api) didn't give me an answer. i considered simply making the setting "doesn't decay" instead of "does decay" instead of reading more mod source code.
- potentially make the decay configurable altogether—this shouldn't be particularly difficult once i work out how to do the above
- probably unknown side effects of me moving code around—the mood/need/hediff relationship seems to be wound extremely tight and i couldn't find a way to cut it without having to rewrite large portions of the decay and need status code, so this is more or less "bolted in".
- translations for the new setting—i didn't want to use a bot to do this because it felt dishonest.

aside, thanks for the amount of work you put in maintaining the mods you do.